### PR TITLE
Make panel resizable and Tweak layout

### DIFF
--- a/caniuse-brackets.css
+++ b/caniuse-brackets.css
@@ -5,16 +5,20 @@
 
 #caniuse_catlistColumn {
 	float:left;
-	width: 300px;
+	width: 30%;
+	min-width: 200px;
 	padding-bottom: 10px;
+	padding-left: 10px;
+	max-height: 300px;
+	overflow-y: auto;
 }
 
 #caniuse_catlist {
-	margin-top:5px
+	margin-top:5px;
 }
 
 #caniuse_filter {
-	width: 100%;
+	width: 96%;
 }
 
 .caniuse_catheader {
@@ -28,8 +32,8 @@
 
 #caniuse_supportdisplay {
 	float:left;
-	width:auto;
-	min-width:700px;
+	width: 60%;
+	min-width: 300px;
 	margin-left: 15px;
 	margin-top: 5px;
 }

--- a/main.js
+++ b/main.js
@@ -16,7 +16,8 @@ define(function (require, exports, module) {
         NativeFileSystem        = brackets.getModule("file/NativeFileSystem").NativeFileSystem,
         FileUtils               = brackets.getModule("file/FileUtils"),
         ExtensionUtils          = brackets.getModule("utils/ExtensionUtils"),
-        Menus                   = brackets.getModule("command/Menus");
+        Menus                   = brackets.getModule("command/Menus"),
+        Resizer                 = brackets.getModule("utils/Resizer");
     
     //commands
     var VIEW_HIDE_CANIUSE = "caniuse.run";
@@ -173,6 +174,9 @@ define(function (require, exports, module) {
             CommandManager.execute(VIEW_HIDE_CANIUSE);
         });
 
+        // AppInit.htmlReady() has already executed before extensions are loaded
+        // so, for now, we need to call this ourself
+        Resizer.makeResizable($('#caniuse').get(0), "vert", "top", 200);
     }
     
     init();

--- a/templates/display.html
+++ b/templates/display.html
@@ -1,10 +1,10 @@
-<div id="caniuse" class="bottom-panel">
+<div id="caniuse" class="bottom-panel vert-resizable top-resizer">
 
 	<div class="toolbar simple-toolbar-layout">
 		<div class="title">CanIUse</div><a href="#" class="close">&times;</a>
 	</div>
 
-	<div class="caniuse_contentdiv">
+	<div class="caniuse_contentdiv resizable-content">
 	
 		<div id="caniuse_catlistColumn">
 			<input id="caniuse_filter" type="search" placeholder="Type to filter"><br/>


### PR DESCRIPTION
List of changes:
1. I made the bottom panel resizable. This requires changes to brackets repo that won’t be available until Sprint 16 for people running an installed version, but is available now if you pull from the repo. For Sprint 15, it shouldn't break the panel, but may show some exceptions in the console, but you may want to wait until Sprint 16 is released to merge it.

This only requires 3 classes added to HTML and a single line of code (and a new module) in main.js, so it will be easy to use this as an example to convert you're other panels.
1. I tweaked the CSS to make the category list and feature table display side-by-side (as long as panel width is 500px or so wide, which should be most of the time).
2. The last change I tried is to make the category list scrollable so you can scroll the list on the left and still see the feature table on the right. This works pretty well with some constraints that I can explain if you’re interested.
