### PR TITLE
use bolder colors so table is easier to read

### DIFF
--- a/caniuse-brackets.css
+++ b/caniuse-brackets.css
@@ -61,7 +61,7 @@
 	line-height: 1em;
 }
 
-.caniuse_y { background-color:#9f3; }
-.caniuse_n { background-color:#f99; }
-.caniuse_a { background-color:#cd5; }
+.caniuse_y { background-color:#3c3; }
+.caniuse_n { background-color:#f33; }
+.caniuse_a { background-color:#ff0; }
 .caniuse_u { background-color:#ccc; }


### PR DESCRIPTION
Hi Ray,

The good news is that I actually am using this extension. I was curious about web worker support.

The bad news is that I am partially color blind so I cannot differentiate between the colors for "supported" and "partially supported", so I made them much more bold.

I thought you might be interested in this change. Feel feel to ignore it.

Thanks,
Randy
